### PR TITLE
Lucas 05 abril

### DIFF
--- a/styles/responsive-cadastro-videos.css
+++ b/styles/responsive-cadastro-videos.css
@@ -28,6 +28,12 @@
     }
 }
 
+@media screen and (max-width: 596px) {
+    .modalBox {
+        width: 90%;
+    }
+}
+
 @media screen and (max-width: 426px) {
     body {
         padding: 1rem;


### PR DESCRIPTION
Modal sair está responsivo para mobile nas páginas de cadastro de vídeos. Resolvido problema em que os botôes encavalavam.